### PR TITLE
feat: support OCaml 4.14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Build and test
+name: Build
 
 on: [push, pull_request]
 
@@ -7,27 +7,25 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runs-on: [ ubuntu-latest, macos-latest ]
-        ocaml-compiler: [ "5.4" ]
+        runs-on: [ ubuntu-latest ]
+        rocq_version: [ "dev" ]
     runs-on: ${{ matrix.runs-on }}
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
 
-      - name: Set-up OCaml
-        uses: ocaml/setup-ocaml@v3
+      - name: Build Camltac on Rocq ${{ matrix.rocq_version }}
+        uses: coq-community/docker-coq-action@v1
         with:
-          ocaml-compiler: ${{ matrix.ocaml-compiler }}
-
-      - name: Add Rocq-released Opam repository
-        run: opam repo add rocq-released https://rocq-prover.github.io/opam/released/
-
-      - name: Install Camltac
-        run: opam install .
-
-      - name: Build
-        run: opam exec -- dune build
-
-      - name: Run tests
-        run: opam exec -- dune runtest
+          opam_file: 'camltac.opam'
+          # Add camltac-directives to list of dependencies
+          install: |
+            startGroup "Install dependencies"
+              sudo apt-get update -y -q
+              opam pin add -n -y -k path camltac-directives $WORKDIR
+              opam pin add -n -y -k path $PACKAGE $WORKDIR
+              opam update -y
+              opam install --confirm-level=unsafe-yes -j 2 $PACKAGE --deps-only
+            endGroup
+          coq_version: ${{ matrix.rocq_version }}

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -1,0 +1,27 @@
+name: Examples
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        runs-on: [ ubuntu-latest, macos-latest ]
+        ocaml-compiler: [ "5.4" ]
+    runs-on: ${{ matrix.runs-on }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set-up OCaml
+        uses: ocaml/setup-ocaml@v3
+        with:
+          ocaml-compiler: ${{ matrix.ocaml-compiler }}
+
+      - name: Add Rocq-released Opam repository
+        run: opam repo add rocq-released https://rocq-prover.github.io/opam/released/
+
+      - name: Install Camltac with examples
+        run: opam install .

--- a/camltac-directives.opam
+++ b/camltac-directives.opam
@@ -7,7 +7,7 @@ license: "LGPL-2.1-only"
 homepage: "https://github.com/epfl-systemf/camltac"
 bug-reports: "https://github.com/epfl-systemf/camltac/issues"
 depends: [
-  "dune" {>= "3.22"}
+  "dune" {>= "3.21"}
   "ppxlib"
   "ocamlfind"
   "sexplib"

--- a/camltac-examples.opam
+++ b/camltac-examples.opam
@@ -7,7 +7,7 @@ license: "LGPL-2.1-only"
 homepage: "https://github.com/epfl-systemf/camltac"
 bug-reports: "https://github.com/epfl-systemf/camltac/issues"
 depends: [
-  "dune" {>= "3.22"}
+  "dune" {>= "3.21"}
   "camltac"
   "rocq-stdlib"
   "rocq-stdpp"

--- a/camltac-tests.opam
+++ b/camltac-tests.opam
@@ -7,7 +7,7 @@ license: "LGPL-2.1-only"
 homepage: "https://github.com/epfl-systemf/camltac"
 bug-reports: "https://github.com/epfl-systemf/camltac/issues"
 depends: [
-  "dune" {>= "3.22"}
+  "dune" {>= "3.21"}
   "camltac"
   "rocq-core"
   "odoc" {with-doc}

--- a/camltac.opam
+++ b/camltac.opam
@@ -7,8 +7,8 @@ license: "LGPL-2.1-only"
 homepage: "https://github.com/epfl-systemf/camltac"
 bug-reports: "https://github.com/epfl-systemf/camltac/issues"
 depends: [
-  "ocaml" {>= "5.4"}
-  "dune" {>= "3.22" & < "3.24"}
+  "ocaml" {>= "4.14"}
+  "dune" {>= "3.21" & < "3.24"}
   "rocq-runtime"
   "ppx_rocq"
   "mltac2"

--- a/dune-project
+++ b/dune-project
@@ -1,5 +1,5 @@
-(lang dune 3.22)
-(using rocq 0.12)
+(lang dune 3.21)
+(using rocq 0.11)
 
 (name camltac)
 
@@ -18,7 +18,7 @@
  (name camltac)
  (synopsis "OCaml as a Tactic Language for Rocq")
  (depends
-   (ocaml (>= 5.4))
+   (ocaml (>= 4.14))
    (dune (< 3.24))
    rocq-runtime
    ppx_rocq

--- a/src/directives/ppx_camltac_directives.ml
+++ b/src/directives/ppx_camltac_directives.ml
@@ -12,10 +12,6 @@ module Compiler_options = struct
       (struct let name = "compiler_options" end)
       (struct type t = string list [@@deriving sexp] end)
 
-  let expand ~ctxt options =
-    Property.set options;
-    []
-
   let pattern =
     let option = Ast_pattern.(estring __) in
     let options = Ast_utils.comma_separated option in
@@ -24,8 +20,10 @@ module Compiler_options = struct
   let attribute =
     Attribute.Floating.(declare "camltac.compiler" Context.structure_item pattern Fun.id)
 
-  let rule =
-    Context_free.Rule.attr_str_floating_expect_and_expand attribute expand
+  let check item =
+    match Attribute.Floating.convert_attr_res attribute item with
+    | Ok (Some options) -> Property.set options
+    | _ -> ()
 end
 
 (* Make sure that Findlib is initialized to check packages. *)
@@ -53,11 +51,6 @@ module Library_attribute = struct
     | Error None ->
        Location.raise_errorf ~loc "Could not find package %s." lib
 
-  let expand ~ctxt libs =
-    let libs = List.map check_lib libs in
-    Property.set libs;
-    []
-
   let pattern =
     let library = Ast_pattern.(estring __') in
     let libraries = Ast_utils.comma_separated library in
@@ -66,8 +59,12 @@ module Library_attribute = struct
   let attribute =
     Attribute.Floating.(declare "camltac.using" Context.structure_item pattern Fun.id)
 
-  let rule =
-    Context_free.Rule.attr_str_floating_expect_and_expand attribute expand
+  let check item =
+    match Attribute.Floating.convert_attr_res attribute item with
+    | Ok (Some libs) ->
+       let libs = List.map check_lib libs in
+       Property.set libs
+    | _ -> ()
 end
 
 (** [[@@@ppx]] floating attribute, used to adds preprocessors. *)
@@ -86,11 +83,6 @@ module Ppx_attribute = struct
     | Error None ->
        Location.raise_errorf ~loc "Could not find PPX named %s." ppx
 
-  let expand ~ctxt ppx_list =
-    let ppx_list = List.map check_ppx ppx_list in
-    Property.set ppx_list;
-    []
-
   let pattern =
     let ppx = Ast_pattern.(estring __') in
     let ppx_list = Ast_utils.comma_separated ppx in
@@ -99,19 +91,32 @@ module Ppx_attribute = struct
   let attribute =
     Attribute.Floating.(declare "camltac.ppx" Context.structure_item pattern Fun.id)
 
-  let rule =
-    Context_free.Rule.attr_str_floating_expect_and_expand attribute expand
+  let check item =
+    match Attribute.Floating.convert_attr_res attribute item with
+    | Ok (Some ppx_list) ->
+       let ppx_list = List.map check_ppx ppx_list in
+       Property.set ppx_list
+    | _ -> ()
 end
+
+let ast_iterator =
+  object
+    inherit Ast_traverse.iter as super
+
+    method! structure_item (str: structure_item) =
+      match str.pstr_desc with
+      | Pstr_attribute attribute ->
+         Compiler_options.check attribute;
+         Library_attribute.check attribute;
+         Ppx_attribute.check attribute
+      | _ -> ()
+  end
 
 (**/**)
 
 let () =
   Ppxlib.Driver.register_transformation
-    ~rules:[
-      Compiler_options.rule;
-      Ppx_attribute.rule;
-      Library_attribute.rule
-    ]
+    ~impl:(fun structure -> ast_iterator#structure structure; structure)
     "camltac.directives"
 
 let () = Ppxlib.Driver.standalone ()

--- a/src/main.ml
+++ b/src/main.ml
@@ -5,7 +5,9 @@
 (** {2 Validation} *)
 
 let check_module_name ~loc (name: string) =
-  if not (Char.Ascii.is_upper (String.get name 0)) then
+  match String.get name 0 with
+  | 'A'..'Z' -> ()
+  | _ ->
     let suggestion = String.capitalize_ascii name in
     CErrors.user_err ~loc (Pp.fmt "Module names must be capitalized.\nHint: did you mean %S?" suggestion)
 


### PR DESCRIPTION
This PR enables support for OCaml 4.14, which enables us to use the Docker-Rocq Github Action to speed up the CI. Some examples still require OCaml 5.4 to run properly, so the CI is split in 2 workflows.