### PR TITLE
fix: fix globalization of quotations

### DIFF
--- a/examples/Reification.v
+++ b/examples/Reification.v
@@ -8,7 +8,6 @@ This plugin demonstrates how one can perform reification in Camltac versus Ltac2
 
 From Camltac Require Import Camltac.
 From Ltac2 Require Import Ltac2.
-Require Import Init.Byte. (* TODO: Remove this import when globalization is fixed. *)
 Require Import IdentParsing.
 
 From Stdlib Require Import String Arith.

--- a/src/compiler.ml
+++ b/src/compiler.ml
@@ -66,7 +66,7 @@ let compile ?(context = empty_context) ~(directives: Build_directives.t) ?(infer
       ~include_dirs:[Build_files.modules_dir]
       ~open_modules:(Option.List.cons context.packing_module default_open_modules)
       ~optimize:(`O3)
-      ~extra_args:("-short-paths" :: directives.compiler_options)
+      ~extra_args:("-short-paths" :: "-nopervasives" :: directives.compiler_options)
       ~infer_interface
       ~pp
       impl

--- a/src/module_manager.ml
+++ b/src/module_manager.ml
@@ -66,14 +66,68 @@ let load_module m =
      generate_packing_module ()
   end
 
+(* We persist the runtime environment of each module, so that it can be
+   retrieved upon [Require] or [Import]. *)
+let envs = Summary.ref ~name:"camltac_envs" CString.Map.empty
+
+let cache_envs v =
+  envs := v
+
+let merge_envs v =
+  envs := CString.Map.union (fun key v1 v2 -> Some v2) !envs v
+
+let declare_envs : Runtime.Environment.t CString.Map.t -> Libobject.obj =
+  let open Libobject in
+  declare_object
+    { (default_object "CAMLTAC-ENVS") with
+      cache_function = cache_envs;
+      load_function = (fun _ -> merge_envs);
+      open_function = (fun _ _ -> merge_envs);
+      classify_function = (fun _ -> Keep);
+    }
+
+let set_env m env =
+  Lib.add_leaf (declare_envs (CString.Map.add m.name env !envs))
+
+let get_env m =
+  try CString.Map.find m.name !envs
+  with Not_found ->
+    let env = Runtime.Environment.empty in
+    set_env m env;
+    env
+
 let camltac_module : Libobject.locality * camltac_module -> Libobject.obj =
-  Libobject.declare_object (
-      Libobject.object_with_locality
-        ~stage:Summary.Stage.Interp
-        ~cache:load_module
-        ~subst:None
-        ~discharge:Fun.id
-        "camltac_module")
+  let open Libobject in
+  let load_module m =
+    (* The environment of the module is key to globalization working properly,
+       since it is persisted between [cache_function] and [load_function]. *)
+    let env = get_env m in
+    Runtime.Environment.set_env env;
+    load_module m;
+    let env = Runtime.Environment.get_env () in
+    set_env m env;
+    Runtime.Environment.unset_env ()
+  in
+  declare_object
+  {
+    (default_object ~stage:Summary.Stage.Interp "camltac_module") with
+    cache_function = (fun (_, m) -> load_module m);
+    load_function = (fun _ (locality, m) -> match locality with
+        | Local -> assert false
+        | Export -> ()
+        | SuperGlobal -> load_module m);
+    open_function = simple_open (fun (locality, m) -> match locality with
+        | Local -> assert false
+        | Export -> load_module m
+        | SuperGlobal -> ());
+    classify_function = (fun (locality, _) -> match locality with
+        | Local -> Dispose
+        | Export | SuperGlobal -> Keep);
+    discharge_function =
+      (fun (locality,v) -> match locality with
+         | Local -> None
+         | Export | SuperGlobal -> Some (locality, v));
+  }
 
 let declare_module ~locality name compilation_output =
   let m = { name; compilation_output } in

--- a/src/ocamlfind.ml
+++ b/src/ocamlfind.ml
@@ -76,7 +76,7 @@ let compilation_args
     | Some `O3 when native -> "-O3" :: args
     | _ -> args
   in
-  let args = ["-pp"; pp ^ " -as-pp --use-compiler-pp"] @ args in
+  let args = ["-pp"; pp ^ " -as-pp --use-compiler-pp --cookie ppx_rocq.camltac_mode=true"] @ args in
   let args = extra_args @ args in
   let args = add_arguments "-open" open_modules args in
   let args = add_arguments "-I" include_dirs args in

--- a/src/runtime/environment.ml
+++ b/src/runtime/environment.ml
@@ -4,27 +4,25 @@ open Names
 open Genintern
 
 (** An environment is represented by partial maps from identifiers to values. *)
-type t =
-  { notation_vars: Glob_term.glob_constr option Id.Map.t }
+type t = Glob_term.glob_constr option Id.Map.t
 
-let empty = { notation_vars = Id.Map.empty }
+let empty = Id.Map.empty
 
 let capture glb_sign =
-  let notation_vars = Id.Map.map (fun _ -> None) glb_sign.intern_sign.notation_variable_status in
-  { notation_vars }
+  Id.Map.map (fun _ -> None) glb_sign.intern_sign.notation_variable_status
 
 let map f env =
-  { notation_vars = Id.Map.map (Option.map f) env.notation_vars }
+  Id.Map.map (Option.map f) env
 
 let map_unresolved f env =
   let f var = function
     | Some v -> Some v
     | None -> try f var with _ -> None
   in
-  { notation_vars = Id.Map.mapi f env.notation_vars }
+  Id.Map.mapi f env
 
-let variables { notation_vars } =
-  Id.Map.domain notation_vars
+let variables env =
+  Id.Map.domain env
 
 let env = ref None
 
@@ -42,8 +40,21 @@ let unset_env () =
   env := None
 
 let lookup var =
-  let { notation_vars } = get_env () in
-  match Id.Map.find var notation_vars with
+  let env = get_env () in
+  match Id.Map.find var env with
   | Some v -> v
   | None -> raise Not_found
 
+let persist ~id glob_constr =
+  let v = Id.of_string_soft id in
+  try lookup v
+  with
+  | Missing_environment ->
+     (* Do nothing if there's no environment. *)
+     glob_constr ()
+  | Not_found ->
+    let env = get_env () in
+    let glob_constr = glob_constr () in
+    let env = Id.Map.add v (Some glob_constr) env in
+    set_env env;
+    glob_constr

--- a/src/runtime/environment.mli
+++ b/src/runtime/environment.mli
@@ -8,7 +8,7 @@
 open Names
 
 (** Type of environments. *)
-type t
+type t = Glob_term.glob_constr option Id.Map.t
 
 (** {2 Creating an environment} *)
 
@@ -56,3 +56,7 @@ val unset_env : unit -> unit
     Raises [Missing_environment] if no environment was set using [set_env].
     Raises [Not_found] if the given variable has no value associated to it. *)
 val lookup : Id.t -> Glob_term.glob_constr
+
+(** Persists the given glob_constr in the current implicit environment,
+    or returns the already persisted value. *)
+val persist : id:string -> (unit -> Glob_term.glob_constr) -> Glob_term.glob_constr

--- a/tests/TacInTerm.v
+++ b/tests/TacInTerm.v
@@ -9,9 +9,11 @@ Proof.
   pose (a := 1).
   pose (b := 2).
   refine ocaml:(
-    let open Proofview in
-    let* c = [%constr "a + b"] in
-    Ltac2.exact_no_check c
+    let open Ltac2 in
+    let* a = Control.hyp {%ident| a |} in
+    let* b = Control.hyp {%ident| b |} in
+    let* c = [%constr "%{a} + %{b}"] in
+    exact_no_check c
   ).
 Qed.
 


### PR DESCRIPTION
Fixes the previous behavior of `Require` and `Import` for Camltac modules, which globalized at the `Require` point instead of in the required file. Now quotations are correctly persisted across files.