### PR TITLE
feat: implement locality attributes for `Camltac Run`

### DIFF
--- a/src/grammar.mlg
+++ b/src/grammar.mlg
@@ -88,13 +88,6 @@ VERNAC ARGUMENT EXTEND ocaml_file
      in file, loc }
 END
 
-VERNAC COMMAND EXTEND CamltacRun CLASSIFIED AS SIDEFF
-| [ "Camltac" "Run" ocaml(snippet) ]
-  SYNTERP AS compilation_output
-     { Main.compile_snippet Snippet.Run snippet }
-  -> { Main.interpret Snippet.Run compilation_output }
-END
-
 VERNAC COMMAND EXTEND CamltacEval CLASSIFIED AS QUERY
 | ![proof_opt_query] [ "Camltac" "Eval" ocaml(snippet) ]
   SYNTERP AS synterp_output
@@ -107,10 +100,16 @@ VERNAC COMMAND EXTEND CamltacEval CLASSIFIED AS QUERY
 END
 
 VERNAC COMMAND EXTEND CamltacModule CLASSIFIED AS SIDEFF
+| #[ locality = Attributes.hint_locality ] [ "Camltac" "Run" ocaml(snippet) ]
+  SYNTERP AS synterp_output
+     { let mode = Snippet.Module { name = None; locality } in
+       mode, Main.compile_snippet mode snippet }
+  -> { let mode, compilation_output = synterp_output in
+       Main.interpret mode compilation_output }
+
 | #[ locality = Attributes.hint_locality ] [ "Camltac" "Module" ocaml_module(m) ":=" ocaml(snippet) ]
   SYNTERP AS synterp_output
-     { let name, loc = m in
-       let mode = Snippet.Module { name; loc; locality } in
+     { let mode = Snippet.Module { name = Some m; locality } in
        mode, Main.compile_snippet mode snippet }
   -> { let mode, compilation_output = synterp_output in
        Main.interpret mode compilation_output }
@@ -125,7 +124,7 @@ VERNAC COMMAND EXTEND CamltacModule CLASSIFIED AS SIDEFF
          |> Filename.remove_extension
          |> String.capitalize_ascii
        in
-       let mode = Snippet.Module { name; loc; locality } in
+       let mode = Snippet.Module { name = Some (name, loc); locality } in
        mode, Main.compile_snippet mode snippet }
   -> { let mode, compilation_output = synterp_output in
        Main.interpret mode compilation_output }
@@ -142,7 +141,8 @@ VERNAC COMMAND EXTEND CamltacCheck CLASSIFIED AS QUERY
      { (* [Camltac Check M.] ≅ [Camltac Check ocaml:(include M).] *)
        let module_name, loc = m in
        let snippet = Snippet.make ~loc (Format.sprintf "include %s" module_name) in
-       let scaffold = Snippet.scaffold Snippet.Run snippet in
+       (* FIXME: [scaffold]'s mode should be optional. *)
+       let scaffold = Snippet.scaffold (Snippet.Module { name = None; locality = Libobject.Local }) snippet in
        Main.compile_scaffold ~loc Snippet.Check scaffold }
   -> { Main.interpret Snippet.Check compilation_output }
 

--- a/src/main.ml
+++ b/src/main.ml
@@ -44,12 +44,16 @@ let infer_interface ~loc file =
 let compile_scaffold ~loc mode scaffold =
   let build_file =
     match mode with
-    | Snippet.Module { name; loc = name_loc } ->
-       check_module_name ~loc:name_loc name;
-       if Module_manager.is_loaded name then
-         CErrors.user_err ~loc (Pp.fmt "Module %S already exists." name)
-       else
-         Build_files.save_module scaffold
+    | Snippet.Module { name } ->
+       begin match name with
+       | Some (name, loc) ->
+          check_module_name ~loc name;
+          if Module_manager.is_loaded name then
+            CErrors.user_err ~loc (Pp.fmt "Module %S already exists." name)
+          else
+            Build_files.save_module scaffold
+       | _ -> Build_files.save_snippet scaffold
+       end
     | _ -> Build_files.save_snippet scaffold
   in
   match mode with
@@ -109,6 +113,7 @@ let interpret ?proof (mode: Snippet.execution_mode) (Compiler.{ compiled_file; d
      Feedback.msg_info Pp.(str "- : " ++ str typ ++ spc () ++ str "=" ++ spc () ++ str result)
   | Module { locality; name } ->
      (* [Module_manager] handles module loading. *)
+     let name = Option.map fst name in
      Module_manager.declare_module ~locality name compilation_output
   | _ ->
      Loader.load_file ~public:false ~dependencies compiled_file

--- a/src/module_manager.ml
+++ b/src/module_manager.ml
@@ -1,7 +1,7 @@
 (** Handles backtrack state for modules. *)
 
 type camltac_module =
-  { name: string;
+  { name: string option;
     compilation_output: Compiler.output }
 
 type state =
@@ -17,7 +17,11 @@ let state =
     { loaded_modules = []; loaded_dependencies = []; packing_module = None }
 
 let is_loaded m =
-  let module_name_eq m' = String.equal m'.name m in
+  let module_name_eq m' =
+    match m'.name with
+    | Some m' -> String.equal m m'
+    | None -> false
+  in
   List.exists module_name_eq !state.loaded_modules
 
 let loaded_dependencies () =
@@ -32,7 +36,9 @@ let module_name filename =
 let module_aliases () =
   let module_alias { name; compilation_output } =
     let real_name = module_name compilation_output.compiled_file in
-    Format.sprintf "module %s = %s" name real_name
+    match name with
+    | Some name -> Format.sprintf "module %s = %s" name real_name
+    | _ -> ""
   in
   (* First element = most recent, so reverse the order. *)
   let aliases = List.rev_map module_alias !state.loaded_modules in
@@ -58,13 +64,15 @@ let generate_packing_module () =
 
 let load_module m =
   let { name; compilation_output } = m in
-  if not (is_loaded name) then begin
-     let Compiler.{ compiled_file; dependencies } = compilation_output in
+  (* Don't load the module twice. *)
+  match name with
+  | Some name when is_loaded name -> ()
+  | _ ->
+     let Compiler.{ compiled_file; dependencies } = m.compilation_output in
      Loader.load_file ~public:true ~dependencies compiled_file;
      state := { !state with loaded_modules = m :: !state.loaded_modules;
                             loaded_dependencies = dependencies @ !state.loaded_dependencies };
      generate_packing_module ()
-  end
 
 (* We persist the runtime environment of each module, so that it can be
    retrieved upon [Require] or [Import]. *)
@@ -87,14 +95,22 @@ let declare_envs : Runtime.Environment.t CString.Map.t -> Libobject.obj =
     }
 
 let set_env m env =
-  Lib.add_leaf (declare_envs (CString.Map.add m.name env !envs))
+  match m.name with
+  | Some name -> Lib.add_leaf (declare_envs (CString.Map.add name env !envs))
+  | None -> ()
 
 let get_env m =
-  try CString.Map.find m.name !envs
-  with Not_found ->
-    let env = Runtime.Environment.empty in
-    set_env m env;
-    env
+  match m.name with
+  | None ->
+     (* Don't track anonymous modules. *)
+     Runtime.Environment.empty
+  | Some name ->
+     try CString.Map.find name !envs
+     with Not_found ->
+       let env = Runtime.Environment.empty in
+       set_env m env;
+       env
+
 
 let camltac_module : Libobject.locality * camltac_module -> Libobject.obj =
   let open Libobject in

--- a/src/module_manager.mli
+++ b/src/module_manager.mli
@@ -6,7 +6,7 @@ val is_loaded : string -> bool
 (** [is_loaded m] returns [true] if a module named [m] is already loaded into
     the main program. *)
 
-val declare_module : locality:Libobject.locality -> string -> Compiler.output -> unit
+val declare_module : locality:Libobject.locality -> string option -> Compiler.output -> unit
 (** [declare_module ~locality m compilation_output] declares a new Camltac module
     named [m]. The [locality] argument specifies whether the module is accessible outside of the
     current module:

--- a/src/snippet.ml
+++ b/src/snippet.ml
@@ -38,10 +38,9 @@ let contents { contents } = contents
 (** {1 Scaffolds} *)
 
 type execution_mode =
-  | Run
   | Eval of string
   | Check
-  | Module of { name: string; loc: Loc.t; locality: Libobject.locality }
+  | Module of { name: (string * Loc.t) option; locality: Libobject.locality }
   | Tactic_in_term
   | Tactic_in_Ltac
   | Tactic_in_Ltac2
@@ -137,7 +136,7 @@ let scaffold mode snippet =
        Some "in (return (show x)) end"
     | Tactic_in_term | Tactic_in_Ltac | Tactic_in_Ltac2 ->
        Some "let t : unit tactic =", Some "in Runtime.Output.set_tactic t"
-    | Run | Module _ ->
+    | Module _ ->
        None, None
   in
   Scaffold.make ?header ?footer snippet

--- a/src/snippet.mli
+++ b/src/snippet.mli
@@ -33,14 +33,12 @@ val contents : t -> string
 (** Execution mode of a snippet, determining how a snippet should be
     interpreted. *)
 type execution_mode =
-  | Run                        (** OCaml code that is run for its side-effects ([Camltac Run ocaml:(…)]). *)
   | Eval of string             (** Evaluation of OCaml tactics ([Camltac Eval ocaml:(…)]). *)
   | Check                      (** Type-checking OCaml expressions ([Camltac Check ocaml:(…)]). *)
   | Module of {
-      name: string;
-      loc: Loc.t;
+      name: (string * Loc.t) option;
       locality: Libobject.locality
-    }                          (** OCaml top-level declarations ([Camltac Module M := ocaml:(…)]). *)
+    }                          (** OCaml top-level declarations ([Camltac Module M := ocaml:(…)] or [Camltac Run] if [name] is [None]). *)
   | Tactic_in_term             (** Tactic-in-term modality (e.g. [Definition x := ocaml:(…)]). *)
   | Tactic_in_Ltac             (** Tactic-in-Ltac modality (e.g. [Ltac f := ocaml:(…)]). *)
   | Tactic_in_Ltac2            (** Tactic-in-Ltac2 modality (e.g. [Ltac2 f () := ocaml:(…)]). *)

--- a/tests/issues/Issue8.v
+++ b/tests/issues/Issue8.v
@@ -1,0 +1,11 @@
+Require Import Camltac.Camltac.
+Require Import Ltac2.Ltac2.
+
+Camltac Run ocaml:{{
+  Ltac2.FFI.(define "foo" (unit @-> ret unit) (fun () -> ()))
+}}.
+
+Ltac2 @external foo : unit -> unit := "camltac.plugin.runtime" "foo".
+
+(** Should suceed: *)
+Succeed Ltac2 Eval (foo ()).

--- a/tests/issues/Issue8_2.v
+++ b/tests/issues/Issue8_2.v
@@ -1,0 +1,4 @@
+Require Import Issue8.
+
+(** Should suceed: *)
+Ltac2 Eval (foo ()).


### PR DESCRIPTION
We now treat `Camltac Run` as anonymous modules, which can persist their effects using `#[export]` or `#[global]`.

Fixes #8.