### PR TITLE
fix: avoid name clashes on `Stdlib`

### DIFF
--- a/src/api/prelude.ml
+++ b/src/api/prelude.ml
@@ -16,11 +16,9 @@ include Terms.Definitions
 
 type valexpr = Ltac2_plugin.Tac2val.valexpr
 
-(** Shadow the standard OCaml library to mark some functions as unsafe or not
-    working as intended. *)
-module Stdlib : sig
-  include module type of Stdlib
-
+(** Shadow functions from the standard OCaml library to mark them as unsafe or
+    not working as intended. *)
+include (Stdlib : sig
   val stdin  : in_channel  [@@alert camltac_io "stdin does not work in Camltac."]
   val stdout : out_channel [@@alert camltac_io "stdout does not lead to correct output; use Feedback instead."]
   val stderr : out_channel [@@alert camltac_io "stderr does not lead to correct ouput; use CErrors instead."]
@@ -46,10 +44,4 @@ module Stdlib : sig
   val read_int : unit -> int [@@alert camltac_io "read_int does not work in Camltac."]
   val read_float_opt : unit -> float option [@@alert camltac_io "read_float_opt does not work in Camltac."]
   val read_float : unit -> float [@@alert camltac_io "read_float does not work in Camltac."]
-
-  val ref : 'a -> 'a ref [@@alert camltac_ref "Using ref at the top-level is most likely a mistake; use Summary.ref instead or stdlib_ref if you're sure of what you're doing."]
-  val stdlib_ref : 'a -> 'a ref
-end = struct
-  include Stdlib
-  let stdlib_ref = ref
-end
+end)

--- a/src/compiler.ml
+++ b/src/compiler.ml
@@ -12,7 +12,7 @@ let default_packages =
 
 (** Set of modules open by default. *)
 let default_open_modules =
-  ["Api"; "Prelude"; "Prelude.Stdlib"]
+  ["Api"; "Prelude"]
 
 (** Relativize [filename] against [dir]. *)
 let relativize ~dir filename =
@@ -66,7 +66,7 @@ let compile ?(context = empty_context) ~(directives: Build_directives.t) ?(infer
       ~include_dirs:[Build_files.modules_dir]
       ~open_modules:(Option.List.cons context.packing_module default_open_modules)
       ~optimize:(`O3)
-      ~extra_args:("-short-paths" :: "-nopervasives" :: directives.compiler_options)
+      ~extra_args:("-short-paths" :: directives.compiler_options)
       ~infer_interface
       ~pp
       impl


### PR DESCRIPTION
We also remove the alert on `ref`, since we cannot differentiate between top-level refs (which should use `Summary.ref`) and local refs, which are fine.